### PR TITLE
Fix README output examples and add project docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,9 @@ cython_debug/
 # VS Code
 .vscode/
 
+# Claude Code
+.claude/
+
 # macOS
 .DS_Store
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`text_converters` is a pure Python PyPI package (v1.0.0) for converting accented/special characters from Greek, Swedish, German, French, and Spanish to their English equivalents. Zero runtime dependencies, Python 3.8+ compatible.
+
+## Commands
+
+```bash
+pip install -e ".[dev]"                          # Install with dev dependencies
+
+pytest tests/ -v                                 # Run all tests
+pytest tests/ -v --cov=text_converters           # With coverage
+pytest tests/test_character_converters.py::TestGreekConversion::test_basic_greek_conversion -v  # Single test
+
+flake8 text_converters/ --max-line-length=127    # Lint (max-line-length=127, not 88)
+black --check text_converters/                   # Format check
+isort --check-only text_converters/              # Import sort check
+mypy text_converters/ --ignore-missing-imports   # Type check
+```
+
+## Architecture
+
+Single-module package. All logic lives in `text_converters/character_converters.py`; `__init__.py` re-exports everything as the public API.
+
+**Core pattern:** each language converter is a plain function that does `return "".join(MAPPING.get(c, c) for c in text)` against a static `Dict[str, str]`. All converters are collected in the `CHARACTER_CONVERTERS` dict, keyed by language name string.
+
+**Public API** (from `__init__.py`):
+- `convert_greek_characters_to_english(text)`, `convert_swedish_characters_to_english(text)`, `convert_german_characters_to_english(text)`, `convert_french_characters_to_english(text)`, `convert_spanish_characters_to_english(text)`, `no_conversion(text)`
+- `CHARACTER_CONVERTERS` — dict mapping language name → converter function
+- `get_character_converter(language="none")` — returns the appropriate function or raises `ValueError`
+
+## CI
+
+`.github/workflows/ci.yml` runs three parallel jobs on push/PR:
+1. **lint** — flake8 (two passes: strict errors, then warnings with max-line-length=127) + mypy
+2. **format** — black --check + isort --check-only
+3. **test** — pytest matrix across Python 3.8–3.12 with Codecov upload
+
+Note: flake8 uses `--max-line-length=127`, but black is configured for line-length=88 in `pyproject.toml`. Don't introduce lines between 89–127 chars unless intentional.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ from text_converters import convert_greek_characters_to_english
 # Convert Greek text to English
 greek_text = "Αθήνα"
 english_text = convert_greek_characters_to_english(greek_text)
-print(english_text)  # Output: "Athena"
+print(english_text)  # Output: "Athhna"
 ```
 
 ### Using the Character Converter Dictionary
@@ -88,7 +88,7 @@ from text_converters import get_character_converter
 
 # Get a converter by language name
 converter = get_character_converter("greek")
-result = converter("Καλησπέρα")  # "Kalispera"
+result = converter("Καλησπέρα")  # "Kalhspera"
 
 # Handle unsupported languages
 try:
@@ -110,7 +110,7 @@ from text_converters import (
 greek_result = convert_greek_characters_to_english("Γεια σας")  # "Geia sas"
 
 # German
-german_result = convert_german_characters_to_english("Grüße")  # "GrUesse"
+german_result = convert_german_characters_to_english("Grüße")  # "Gruesse"
 
 # French
 french_result = convert_french_characters_to_english("Bonjour")  # "Bonjour"
@@ -120,9 +120,9 @@ french_result = convert_french_characters_to_english("Bonjour")  # "Bonjour"
 
 | Language | Function | Example |
 |----------|----------|---------|
-| Greek | `convert_greek_characters_to_english` | "Αθήνα" → "Athena" |
+| Greek | `convert_greek_characters_to_english` | "Αθήνα" → "Athhna" |
 | Swedish | `convert_swedish_characters_to_english` | "Göteborg" → "Goteborg" |
-| German | `convert_german_characters_to_english` | "Grüße" → "GrUesse" |
+| German | `convert_german_characters_to_english` | "Grüße" → "Gruesse" |
 | French | `convert_french_characters_to_english` | "Café" → "Cafe" |
 | Spanish | `convert_spanish_characters_to_english` | "España" → "Espana" |
 | None | `no_conversion` | "Hello" → "Hello" |


### PR DESCRIPTION
## Summary

- Correct Greek and German conversion output examples to match actual behaviour
- Add CLAUDE.md with project guidance for Claude Code
- Add .claude/ to .gitignore

## Test plan

- [ ] Required status checks pass (CI)
- [ ] No code changes — docs and config only